### PR TITLE
Use Netlify's new structured redirect rules

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -20,8 +20,6 @@ page "/*.json", layout: false
 page "/*.txt", layout: false
 page "/*.xml", layout: false
 
-proxy("_redirects", "netlify_redirects", ignore: true)
-
 configure :development do
   activate :livereload do |reload|
     reload.no_swf = true

--- a/source/netlify.toml
+++ b/source/netlify.toml
@@ -1,0 +1,23 @@
+[build]
+  publish = "build"
+  command = "bundle exec middleman build --verbose"
+
+[[redirects]]
+  from = "/changes/"
+  to = "/blog/tags/changes/"
+  status = 301
+
+[[redirects]]
+  from = "/results/"
+  to = "/"
+  status = 301
+
+[[redirects]]
+  from = "/sign_in/"
+  to = "/"
+  status = 301
+
+[[redirects]]
+  from = "/sign_up/"
+  to = "/"
+  status = 301

--- a/source/netlify_redirects
+++ b/source/netlify_redirects
@@ -1,4 +1,0 @@
-/changes/ /blog/tags/changes/ 301
-/results/ / 301
-/sign_in/ / 301
-/sign_up/ / 301


### PR DESCRIPTION
This allows us to get around the hack we had in place to create a
`_redirects` file at the root of the project.

Structured rules announcement:
https://www.netlify.com/blog/2017/10/17/introducing-structured-redirects-and-headers/

Structured rules docs:
https://www.netlify.com/docs/redirects/#structured-configuration